### PR TITLE
Update Docker versions and pip packages

### DIFF
--- a/FORECAST/CLEAN_AND_MERGE/Docker/Dockerfile
+++ b/FORECAST/CLEAN_AND_MERGE/Docker/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the APACHE 2 License. See LICENSE file in the project root for
 # full license information.
 # =============================================================================
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image 3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/FORECAST/CLEAN_AND_MERGE/Docker/requirements.txt
+++ b/FORECAST/CLEAN_AND_MERGE/Docker/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.22.0
+numpy==1.24.1
 scipy==1.10.1
-netCDF4==1.5.3
+netCDF4==1.7.4
 cfgrib==0.9.10.4
 xarray==2023.1.0

--- a/FORECAST/MERGE/Docker/Dockerfile
+++ b/FORECAST/MERGE/Docker/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the APACHE 2 License. See LICENSE file in the project root for
 # full license information.
 # =============================================================================
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/FORECAST/MERGE/Docker/requirements.txt
+++ b/FORECAST/MERGE/Docker/requirements.txt
@@ -1,3 +1,4 @@
-netCDF4==1.5.3
+netCDF4==1.7.4
 cfgrib==0.9.10.4
+numpy==1.24.1
 xarray==2023.1.0

--- a/FORECAST/REQUEST/GFS/Docker/Dockerfile
+++ b/FORECAST/REQUEST/GFS/Docker/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the APACHE 2 License. See LICENSE file in the project root for
 # full license information.
 # =============================================================================
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/FORECAST/REQUEST/ICON_EU/Docker/Dockerfile
+++ b/FORECAST/REQUEST/ICON_EU/Docker/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the APACHE 2 License. See LICENSE file in the project root for
 # full license information.
 # =============================================================================
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/FORECAST/REQUEST/ICON_GLOBAL/Docker/Dockerfile
+++ b/FORECAST/REQUEST/ICON_GLOBAL/Docker/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the APACHE 2 License. See LICENSE file in the project root for
 # full license information.
 # =============================================================================
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/FORECAST/REQUEST/IFS/Docker/Dockerfile
+++ b/FORECAST/REQUEST/IFS/Docker/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the APACHE 2 License. See LICENSE file in the project root for
 # full license information.
 # =============================================================================
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/REANALYSIS/MERGE/Docker/Dockerfile
+++ b/REANALYSIS/MERGE/Docker/Dockerfile
@@ -1,5 +1,5 @@
-# 1. Base image 3.8.10-slim
-FROM python:3.8
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/REANALYSIS/MERGE/Docker/requirements.txt
+++ b/REANALYSIS/MERGE/Docker/requirements.txt
@@ -1,3 +1,4 @@
-netCDF4==1.5.3
+netCDF4==1.7.4
 cfgrib==0.9.10.4
+numpy==1.24.1
 xarray==2023.1.0

--- a/REANALYSIS/REQUEST/ERA5_PRESSURE_LEVELS/Docker/Dockerfile
+++ b/REANALYSIS/REQUEST/ERA5_PRESSURE_LEVELS/Docker/Dockerfile
@@ -1,5 +1,5 @@
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app

--- a/REANALYSIS/REQUEST/ERA5_SINGLE_LEVEL/Docker/Dockerfile
+++ b/REANALYSIS/REQUEST/ERA5_SINGLE_LEVEL/Docker/Dockerfile
@@ -1,5 +1,5 @@
-# 1. Base image 3.8.10-slim
-FROM python:3.8.10-slim
+# 1. Base image python:3.10-slim
+FROM python:3.10-slim
 
 # sets the working directory for the container : all commands will be run from this directory
 WORKDIR /home/app


### PR DESCRIPTION
## ✨ Summary

This Merge Request updates the Python runtime and core scientific dependencies across all **FORECAST** and **REANALYSIS** Docker images.

### 🔧 Technical changes

#### 🐍 Python version upgrade

* All Docker images are upgraded from **Python 3.8.x** to **Python 3.10-slim**
* Applies consistently to:

  * FORECAST (CLEAN_AND_MERGE, MERGE, REQUEST: GFS, ICON_EU, ICON_GLOBAL, IFS)
  * REANALYSIS (MERGE, REQUEST: ERA5 pressure & single levels)

#### 📦 Dependency updates

Updated pip packages to recent, Python 3.10–compatible versions:

* **numpy**: `1.22.0 → 1.24.1`
* **netCDF4**: `1.5.3 → 1.7.4`
* **scipy**: `1.10.1` (unchanged)
* **cfgrib**: `0.9.10.4` (unchanged)
* **xarray**: `2023.1.0` (unchanged)

Dependencies were aligned across FORECAST and REANALYSIS images to ensure consistency.

---

### ✅ Motivation & benefits

* Align runtime with a **supported Python version**
* Improve **long-term maintainability**
* Ensure compatibility with **recent scientific Python ecosystems**
* Reduce divergence between Docker images

---

### ⚠️ Impact & validation

* No functional logic changes
* Docker images must be rebuilt
* Pip dependencies remain pinned to avoid breaking changes

